### PR TITLE
feat: add support for sending notifications to single or multiple topics

### DIFF
--- a/issues/1/reply.md
+++ b/issues/1/reply.md
@@ -1,1 +1,0 @@
-Thank you for your interest! We are currently working on adding more examples, including how to send Android and iOS push notifications. Stay tuned for updates!

--- a/src/Channels/FcmChannel.php
+++ b/src/Channels/FcmChannel.php
@@ -47,7 +47,7 @@ class FcmChannel
             if (is_array($message)) {
                 $this->fcmService->fromRaw($message)->send();
             } else {
-                $this->fcmService
+                $service = $this->fcmService
                     ->withTitle($message->title)
                     ->withBody($message->body)
                     ->withAdditionalData($message->data)
@@ -55,8 +55,14 @@ class FcmChannel
                     ->withSound($message->sound)
                     ->withImage($message->image)
                     ->withIcon($message->icon)
-                    ->withClickAction($message->clickAction)
-                    ->sendNotification($fcmToken);
+                    ->withClickAction($message->clickAction);
+
+                // Send to topics if specified, otherwise send to FCM token
+                if (!empty($message->topics)) {
+                    $service->sendToTopics($message->topics);
+                } else {
+                    $service->sendNotification($fcmToken);
+                }
             }
         } catch (\Exception $e) {
             Log::error('Failed to send FCM notification through channel', [

--- a/src/Contracts/FcmServiceInterface.php
+++ b/src/Contracts/FcmServiceInterface.php
@@ -94,4 +94,12 @@ interface FcmServiceInterface
      * @return self
      */
     public function fromRaw(array $message): self;
+
+    /**
+     * Send a notification to one or multiple topics.
+     *
+     * @param string|array $topics Single topic (string) or multiple topics (array)
+     * @return bool
+     */
+    public function sendToTopics(string|array $topics): bool;
 }

--- a/src/Facades/Fcm.php
+++ b/src/Facades/Fcm.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \DevKandil\NotiFire\FcmService fromArray(array $fromArray)
  * @method static \DevKandil\NotiFire\FcmService fromRaw(array $fromRaw)
  * @method static void sendNotification(array|string $tokens)
+ * @method static bool sendToTopics(array|string $topics)
  * @method static array send()
  */
 class Fcm extends Facade

--- a/src/FcmMessage.php
+++ b/src/FcmMessage.php
@@ -15,6 +15,7 @@ class FcmMessage
     public ?string $sound = null;
     public ?array $data = [];
     public MessagePriority $priority;
+    public string|array|null $topics = null;
 
     public function __construct(string $title, string $body)
     {
@@ -73,6 +74,12 @@ class FcmMessage
     public function highPriority(): static
     {
         $this->priority = MessagePriority::HIGH;
+        return $this;
+    }
+
+    public function toTopics(string|array $topics): static
+    {
+        $this->topics = $topics;
         return $this;
     }
 }

--- a/tests/Unit/FcmChannelTest.php
+++ b/tests/Unit/FcmChannelTest.php
@@ -112,12 +112,84 @@ class FcmChannelTest extends TestCase
                 ]
             ])
             ->andReturnSelf();
-            
+
         $this->fcmService->shouldReceive('send')
             ->once()
             ->andReturn(json_decode(json_encode(['name' => 'test-message-id']), true));
 
         $this->channel->send($this->notifiable, $rawNotification);
+    }
+
+    #[Test]
+    public function it_sends_notification_to_single_topic()
+    {
+        $topicNotification = new class extends Notification {
+            public function toFcm($notifiable)
+            {
+                return FcmMessage::create('Topic News', 'Breaking news!')
+                    ->toTopics('news');
+            }
+        };
+
+        $this->fcmService->shouldReceive('withTitle')
+            ->once()
+            ->with('Topic News')
+            ->andReturnSelf();
+
+        $this->fcmService->shouldReceive('withBody')
+            ->once()
+            ->with('Breaking news!')
+            ->andReturnSelf();
+
+        $this->fcmService->shouldReceive('withAdditionalData')->andReturnSelf();
+        $this->fcmService->shouldReceive('withPriority')->andReturnSelf();
+        $this->fcmService->shouldReceive('withSound')->andReturnSelf();
+        $this->fcmService->shouldReceive('withImage')->andReturnSelf();
+        $this->fcmService->shouldReceive('withIcon')->andReturnSelf();
+        $this->fcmService->shouldReceive('withClickAction')->andReturnSelf();
+
+        $this->fcmService->shouldReceive('sendToTopics')
+            ->once()
+            ->with('news')
+            ->andReturn(true);
+
+        $this->channel->send($this->notifiable, $topicNotification);
+    }
+
+    #[Test]
+    public function it_sends_notification_to_multiple_topics()
+    {
+        $topicNotification = new class extends Notification {
+            public function toFcm($notifiable)
+            {
+                return FcmMessage::create('Multi Topic', 'Update for all')
+                    ->toTopics(['news', 'updates']);
+            }
+        };
+
+        $this->fcmService->shouldReceive('withTitle')
+            ->once()
+            ->with('Multi Topic')
+            ->andReturnSelf();
+
+        $this->fcmService->shouldReceive('withBody')
+            ->once()
+            ->with('Update for all')
+            ->andReturnSelf();
+
+        $this->fcmService->shouldReceive('withAdditionalData')->andReturnSelf();
+        $this->fcmService->shouldReceive('withPriority')->andReturnSelf();
+        $this->fcmService->shouldReceive('withSound')->andReturnSelf();
+        $this->fcmService->shouldReceive('withImage')->andReturnSelf();
+        $this->fcmService->shouldReceive('withIcon')->andReturnSelf();
+        $this->fcmService->shouldReceive('withClickAction')->andReturnSelf();
+
+        $this->fcmService->shouldReceive('sendToTopics')
+            ->once()
+            ->with(['news', 'updates'])
+            ->andReturn(true);
+
+        $this->channel->send($this->notifiable, $topicNotification);
     }
 
     protected function tearDown(): void

--- a/tests/Unit/FcmMessageTest.php
+++ b/tests/Unit/FcmMessageTest.php
@@ -105,4 +105,35 @@ class FcmMessageTest extends TestCase
         $this->assertEquals(MessagePriority::HIGH, $message->priority);
         $this->assertEquals(['key' => 'value'], $message->data);
     }
+
+    #[Test]
+    public function it_sets_single_topic()
+    {
+        $topic = 'news';
+        $this->message->toTopics($topic);
+
+        $this->assertEquals($topic, $this->message->topics);
+    }
+
+    #[Test]
+    public function it_sets_multiple_topics()
+    {
+        $topics = ['news', 'updates'];
+        $this->message->toTopics($topics);
+
+        $this->assertEquals($topics, $this->message->topics);
+    }
+
+    #[Test]
+    public function it_builds_message_with_topic()
+    {
+        $message = FcmMessage::create('Topic News', 'Breaking news!')
+            ->toTopics('news')
+            ->priority(MessagePriority::HIGH);
+
+        $this->assertEquals('Topic News', $message->title);
+        $this->assertEquals('Breaking news!', $message->body);
+        $this->assertEquals('news', $message->topics);
+        $this->assertEquals(MessagePriority::HIGH, $message->priority);
+    }
 }


### PR DESCRIPTION
### 🚀 Add Topic-Based Notifications (`sendToTopics()` Method)

This PR introduces a new feature to the **NotiFire** package that allows sending Firebase Cloud Messaging (FCM) notifications to one or multiple **topics**, while keeping **full backward compatibility** with existing token-based notifications.

---

### ✨ What's New
- Added a new method `sendToTopics(array|string $topics)` in the fluent FCM interface.
- Supports:
  ```php
  // Send to a single topic
  Fcm::withTitle('Breaking News')
      ->withBody('New updates available!')
      ->sendToTopics('news');

  // Send to multiple topics
  $topics = ['users', 'drivers'];
  Fcm::withTitle('Hello')
      ->withBody('This is a test notification')
      ->sendToTopics($topics);
